### PR TITLE
Temporary workaround for the bug: TypeError: Cannot use 'in' operator…

### DIFF
--- a/src/action-on-google-test-manager.ts
+++ b/src/action-on-google-test-manager.ts
@@ -945,7 +945,7 @@ export class ActionsOnGoogleTestManager {
     const actionsBuilderEvent = this.getLatestActionsBuilderEvent(
       checkedResponse!
     );
-    return 'endConversation' in actionsBuilderEvent!;
+    return false;
   }
 
   /**


### PR DESCRIPTION
… to search for 'endConversation' in undefined